### PR TITLE
Add Starlight documentation task to project planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ Try DS one in your browser: **[ds-one.dev/demo](https://ds-one.dev/demo)**
 - Enhanced theming documentation
 - Component testing suite
 - Storybook integration
+- Starlight documentation site with component and theming guides
 
 ### Planned (0.2.0+)
 

--- a/docs/issue-list.md
+++ b/docs/issue-list.md
@@ -1,0 +1,16 @@
+# DS one Issue List
+
+This document tracks outstanding tasks derived from the DS one specification and roadmap. Use it to coordinate work that has not
+been captured in GitHub issues yet.
+
+## Documentation
+
+### Starlight documentation site
+
+- [ ] Build a Starlight-powered documentation site that consolidates DS one guidance across installation, usage, and maintenance.
+  - [ ] Surface all installation methods (npm, Bun, Yarn, CDN) with copyable snippets (_specification §Installation Methods_).
+  - [ ] Explain the package/file structure so developers can locate components, units, pages, and supporting assets (_specification §File Structure_).
+  - [ ] Provide development workflow coverage (dev server, tests, builds, publishing) so teams can follow the recommended lifecycle (_specification §Development Workflow_).
+  - [ ] Document release checklists and troubleshooting guidance to keep the docs aligned with pre-publish requirements (_specification §§Pre-publish Checklist & Troubleshooting_).
+
+Update the checklist above as milestones for the documentation site are completed.

--- a/docs/specification.md
+++ b/docs/specification.md
@@ -532,6 +532,7 @@ console.log(customElements.get("button-v1"));
 
 ### Planned Features
 
+- [ ] Starlight documentation site with component, theming, and integration guides
 - [ ] ESM-only package for smaller bundle size
 - [ ] Individual component packages (`@ds-one/button`, `@ds-one/text`)
 - [ ] Framework-specific wrappers (React, Vue, Angular)


### PR DESCRIPTION
## Summary
- add a dedicated issue list file that captures the work required for a Starlight-powered documentation site
- surface the Starlight documentation requirement in the specification and README planning sections

## Testing
- not run (documentation only)


------
https://chatgpt.com/codex/tasks/task_e_68e70d910fc0832a9089206d867039b7

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a Starlight documentation site task to planning and introduces an issue list with a checklist for building it.
> 
> - **Documentation**:
>   - **New**: `docs/issue-list.md` with a checklist for a Starlight-powered documentation site (installation methods, file structure, workflow, release/troubleshooting).
>   - **Planning updates**:
>     - Add Starlight documentation site to `README.md` under `In Progress (0.1.0 Beta Goals)`.
>     - Add planned Starlight documentation site to `docs/specification.md` under `Planned Features`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 56c0fa6ec5378cf192b7d8dfd7ef283f8933b9b2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->